### PR TITLE
lapack now compiles from source to ensure same compiler versions

### DIFF
--- a/climexp_numerical_wps/processes/__init__.py
+++ b/climexp_numerical_wps/processes/__init__.py
@@ -1,8 +1,6 @@
-from .wps_say_hello import SayHello
 from .correlate_field import CorrelateField
 
 
 processes = [
-    SayHello(),
     CorrelateField()
 ]

--- a/environment.yml
+++ b/environment.yml
@@ -13,7 +13,5 @@ dependencies:
 - netcdf-fortran 
 - gsl
 - fortran-compiler 
-- blas
-- lapack
 - pip:
   - -e git+https://github.com/geopython/pywps@master#egg=pywps


### PR DESCRIPTION
## Overview

This PR fixes Docker build error

Changes:

* lapack now compiles from source to ensure same compiler versions

